### PR TITLE
Added JSX.Element as return type to formatter

### DIFF
--- a/react-redux-client-app/src/components/data/react-bootstrap-table-next/types/types.d.ts
+++ b/react-redux-client-app/src/components/data/react-bootstrap-table-next/types/types.d.ts
@@ -312,6 +312,8 @@ overlay={ overlayFactory({ spinner: true, background: 'rgba(192,192,192,0.3)' })
     caption?: string | JSX.Element
     /**Same as bootstrap .table-striped class for adding zebra-stripes to a table. */
     striped?: boolean
+    /**Same as bootstrap .table-hover class for adding mouse hover effect (grey background color) on table rows. */
+    hover?: boolean
     defaultSorted?: Sorted[];
     filter?: FilterProps<TODO>;
     pagination?: Pagination;

--- a/react-redux-client-app/src/components/data/react-bootstrap-table-next/types/types.d.ts
+++ b/react-redux-client-app/src/components/data/react-bootstrap-table-next/types/types.d.ts
@@ -362,7 +362,7 @@ There's only one different for dummy column than normal column, which is dummy c
      *
      * Attention: Don't use any state data or any external data in formatter function, please pass them via formatExtraData. In addition, please make formatter function as pure function as possible as you can.
     */
-    formatter?: (cell: TODO, row: TODO, rowIndex: number, formatExtraData: any) => string
+    formatter?: (cell: TODO, row: TODO, rowIndex: number, formatExtraData: any) => string | JSX.Element
     filter?: TODO;
 
     //     column.headerFormatter - [Function]


### PR DESCRIPTION
According to the original documentation, any formatter should return a string or a Element.